### PR TITLE
Fixed some errors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ TARIFF is an application designed to help international traders navigate current
 ## Getting Started
 
 ### Prerequisites
-- **Node.js** (v18 or higher)
-- **Java** (JDK 17 or higher)
+- **Node.js** (v20.19.0 or higher)
+- **Java** (JDK 17)
 - **PostgreSQL** (for production database)
 
 ### **Clone Repo**
 ```
-git clone https://github.com/your-org/repository-name.git
+git clone https://github.com/TheMajoris/CS203
 ```
 ### **Backend Setup**
 1. **Navigate to the backend directory:**
@@ -53,12 +53,12 @@ cd core
 
 2. **Setup the application:**
 ```bash
-./gradlew build
+bash gradlew build
 ```
 
 3. **Run Tests:**
 ```bash
-./gradlew test
+bash gradlew test
 ```
 ### **Frontend Setup**
 1. **Navigate to the frontend directory:**
@@ -69,6 +69,7 @@ cd frontend
 2. **Install dependencies:**
 ```bash
 npm install
+npx playwright install
 ```
 
 3. **Start development server:**


### PR DESCRIPTION
Quick changes to README to reflect new requirements 

Changes:
- Node.JS requires version 20.19 or higher (as reflected during the installation process)
- Only JDK 17 works with our current implementation of Spring
- Added a playwright install command so that the user won't bump into an error message when executing `npm run test:unit`

