### PR TITLE
SCRUM-20 Basic CRUD Endpoints done

### DIFF
--- a/core/src/main/java/com/cs203/core/controller/TariffRateController.java
+++ b/core/src/main/java/com/cs203/core/controller/TariffRateController.java
@@ -1,0 +1,59 @@
+package com.cs203.core.controller;
+
+import java.util.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cs203.core.dto.CreateTariffRateDto;
+import com.cs203.core.dto.GenericResponse;
+import com.cs203.core.dto.TariffRateDto;
+import com.cs203.core.service.TariffRateService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/tariff-rate")
+public class TariffRateController {
+
+    @Autowired
+    TariffRateService tariffRateService;
+
+    @GetMapping
+    public ResponseEntity<List<TariffRateDto>> getAllTariffRates() {
+        return ResponseEntity.ok(tariffRateService.getAllTariffRates());
+    }
+
+    @GetMapping("/{tariffRateId}")
+    public ResponseEntity<GenericResponse<TariffRateDto>> getTariffRateById(@PathVariable Long tariffRateId) {
+        GenericResponse<TariffRateDto> response = tariffRateService.getTariffRateById(tariffRateId);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<TariffRateDto> createTariffRate(@Valid @RequestBody CreateTariffRateDto createTariffRateDto) {
+        return new ResponseEntity<>(tariffRateService.createTariffRate(createTariffRateDto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{tariffRateId}")
+    public ResponseEntity<GenericResponse<TariffRateDto>> updateTariffRate(
+            @Valid @RequestBody TariffRateDto tariffRateDto, @PathVariable Long tariffRateId) {
+        GenericResponse<TariffRateDto> response = tariffRateService.updateTariffRate(tariffRateDto, tariffRateId);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @DeleteMapping("/{tariffRateId}")
+    public ResponseEntity<GenericResponse<Void>> deleteTariffRate(@PathVariable Long tariffRateId) {
+        GenericResponse<Void> response = tariffRateService.deleteTariffRate(tariffRateId);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+}

--- a/core/src/main/java/com/cs203/core/dto/CreateNationalTariffLinesDto.java
+++ b/core/src/main/java/com/cs203/core/dto/CreateNationalTariffLinesDto.java
@@ -1,0 +1,32 @@
+package com.cs203.core.dto;
+
+import com.cs203.core.entity.CountryEntity;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateNationalTariffLinesDto {
+    private Long id;
+
+    @NotNull(message = "Country is required")
+    private String countryCode;
+
+    @NotBlank(message = "Tariff line code is required")
+    @Size(max = 20, message = "Tariff line code cannot exceed 20 characters")
+    private String tariffLineCode;
+
+    @Size(max = 500, message = "Description cannot exceed 500 characters")
+    private String description;
+
+    @NotNull(message = "Parent HS Code is required")
+    private String parentHsCode;
+
+    @Min(value = 1, message = "Level must be at least 1")
+    @Max(value = 10, message = "Level cannot exceed 10")
+    private Integer level;
+}

--- a/core/src/main/java/com/cs203/core/dto/CreateProductCategoriesDto.java
+++ b/core/src/main/java/com/cs203/core/dto/CreateProductCategoriesDto.java
@@ -1,0 +1,25 @@
+package com.cs203.core.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateProductCategoriesDto {
+    @NotNull(message = "HS code is required")
+    @Min(value = 10, message = "HS code must be at least 2 digits")
+    @Max(value = 999999, message = "HS code cannot exceed 6 digits")
+    private Integer categoryCode;
+
+    @NotBlank(message = "Category name is required")
+    @Size(max = 100, message = "Category name cannot exceed 100 characters")
+    private String categoryName;
+
+    @Size(max = 500, message = "Description cannot exceed 500 characters")
+    private String description;
+
+    // Does not have tariff base rate because there is no way atm to populate it
+}

--- a/core/src/main/java/com/cs203/core/dto/CreateTariffRateDto.java
+++ b/core/src/main/java/com/cs203/core/dto/CreateTariffRateDto.java
@@ -1,0 +1,41 @@
+package com.cs203.core.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateTariffRateDto {
+    @NotNull(message = "Tariff rate is required")
+    @DecimalMin(value = "0.0", message = "Tariff rate must be non-negative")
+    @DecimalMax(value = "999.9999", message = "Tariff rate cannot exceed 999.9999")
+    private BigDecimal tariffRate;
+
+    @NotBlank(message = "Tariff type is required")
+    @Size(max = 50, message = "Tariff type cannot exceed 50 characters")
+    private String tariffType;
+
+    @Size(max = 20, message = "Rate unit cannot exceed 20 characters")
+    private String rateUnit;
+
+    @NotNull(message = "Effective date is required")
+    private LocalDate effectiveDate;
+
+    private LocalDate expiryDate;
+    private Boolean preferentialTariff;
+
+    @NotNull(message = "Importing country is required")
+    private String importingCountryCode;
+
+    @NotNull(message = "Exporting country is required")
+    private String exportingCountryCode;
+
+    @NotNull(message = "HS code is required")
+    private CreateProductCategoriesDto productCategory;
+}

--- a/core/src/main/java/com/cs203/core/dto/GenericResponse.java
+++ b/core/src/main/java/com/cs203/core/dto/GenericResponse.java
@@ -1,0 +1,18 @@
+package com.cs203.core.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Data;
+
+@Data
+public class GenericResponse<E> {
+    private HttpStatus status;
+    private String message;
+    private E data;
+
+    public GenericResponse(HttpStatus status, String message, E data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/core/src/main/java/com/cs203/core/dto/ProductCategoriesDto.java
+++ b/core/src/main/java/com/cs203/core/dto/ProductCategoriesDto.java
@@ -1,0 +1,28 @@
+package com.cs203.core.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ProductCategoriesDto {
+    private Long id;
+    
+    @NotNull(message = "HS code is required")
+    @Min(value = 10, message = "HS code must be at least 2 digits")
+    @Max(value = 999999, message = "HS code cannot exceed 6 digits")
+    private Integer categoryCode;
+
+    @NotBlank(message = "Category name is required")
+    @Size(max = 100, message = "Category name cannot exceed 100 characters")
+    private String categoryName;
+
+    @Size(max = 500, message = "Description cannot exceed 500 characters")
+    private String description;
+
+    private Double tariffBaseRate;
+    private Boolean isActive;
+}

--- a/core/src/main/java/com/cs203/core/dto/TariffRateDto.java
+++ b/core/src/main/java/com/cs203/core/dto/TariffRateDto.java
@@ -1,0 +1,47 @@
+package com.cs203.core.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class TariffRateDto {
+
+    private Long id;
+
+    @NotNull(message = "Tariff rate is required")
+    @DecimalMin(value = "0.0", message = "Tariff rate must be non-negative")
+    @DecimalMax(value = "999.9999", message = "Tariff rate cannot exceed 999.9999")
+    private BigDecimal tariffRate;
+
+    @NotBlank(message = "Tariff type is required")
+    @Size(max = 50, message = "Tariff type cannot exceed 50 characters")
+    private String tariffType;
+
+    @Size(max = 20, message = "Rate unit cannot exceed 20 characters")
+    private String rateUnit;
+
+    @NotNull(message = "Effective date is required")
+    private LocalDate effectiveDate;
+
+    private LocalDate expiryDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean preferentialTariff;
+
+    @NotNull(message = "Importing country is required")
+    private String importingCountryCode;
+
+    @NotNull(message = "Exporting country is required")
+    private String exportingCountryCode;
+    
+    @NotNull(message = "HS code is required")
+    private ProductCategoriesDto productCategory;
+}

--- a/core/src/main/java/com/cs203/core/entity/ProductCategoriesEntity.java
+++ b/core/src/main/java/com/cs203/core/entity/ProductCategoriesEntity.java
@@ -45,6 +45,12 @@ public class ProductCategoriesEntity {
     // Constructors
     public ProductCategoriesEntity() {}
 
+    public ProductCategoriesEntity(Integer categoryCode, String categoryName, String description) {
+        this.categoryCode = categoryCode;
+        this.categoryName = categoryName;
+        this.description = description;
+    }
+
     public ProductCategoriesEntity(Integer categoryCode, String categoryName, String description, Double tariffBaseRate) {
         this.categoryCode = categoryCode;
         this.categoryName = categoryName;

--- a/core/src/main/java/com/cs203/core/entity/TariffRateEntity.java
+++ b/core/src/main/java/com/cs203/core/entity/TariffRateEntity.java
@@ -2,6 +2,7 @@ package com.cs203.core.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 

--- a/core/src/main/java/com/cs203/core/exception/GlobalExceptionHandler.java
+++ b/core/src/main/java/com/cs203/core/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.cs203.core.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private ResponseEntity<Map<String, Object>> createInvalidDataResponse() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        response.put("message", "Data may be invalid. Please check your inputs.");
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        return createInvalidDataResponse();
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, Object>> handleJsonParseExceptions(HttpMessageNotReadableException ex) {
+        return createInvalidDataResponse();
+    }
+}

--- a/core/src/main/java/com/cs203/core/service/TariffRateService.java
+++ b/core/src/main/java/com/cs203/core/service/TariffRateService.java
@@ -1,0 +1,21 @@
+package com.cs203.core.service;
+
+import java.util.*;
+
+import com.cs203.core.dto.CreateTariffRateDto;
+import com.cs203.core.dto.GenericResponse;
+import com.cs203.core.dto.TariffRateDto;
+
+import jakarta.validation.Valid;
+
+public interface TariffRateService {
+    List<TariffRateDto> getAllTariffRates();
+
+    GenericResponse<TariffRateDto> getTariffRateById(Long tariffRateId);
+
+    TariffRateDto createTariffRate(CreateTariffRateDto createTariffRateDto);
+
+    GenericResponse<TariffRateDto> updateTariffRate(TariffRateDto tariffRateDto, Long tariffRateId);
+
+    GenericResponse<Void> deleteTariffRate(Long tariffRateId);
+}

--- a/core/src/main/java/com/cs203/core/service/impl/TariffRateServiceImpl.java
+++ b/core/src/main/java/com/cs203/core/service/impl/TariffRateServiceImpl.java
@@ -1,0 +1,216 @@
+package com.cs203.core.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cs203.core.dto.CreateTariffRateDto;
+import com.cs203.core.dto.GenericResponse;
+import com.cs203.core.dto.TariffRateDto;
+import com.cs203.core.dto.ProductCategoriesDto;
+import com.cs203.core.entity.TariffRateEntity;
+import com.cs203.core.entity.CountryEntity;
+import com.cs203.core.entity.ProductCategoriesEntity;
+import com.cs203.core.repository.TariffRateRepository;
+import com.cs203.core.service.TariffRateService;
+import com.cs203.core.repository.CountryRepository;
+import com.cs203.core.repository.ProductCategoriesRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class TariffRateServiceImpl implements TariffRateService {
+
+    @Autowired
+    private TariffRateRepository tariffRateRepository;
+
+    @Autowired
+    private CountryRepository countryRepository;
+
+    @Autowired
+    private ProductCategoriesRepository productCategoriesRepository;
+
+    // Get all tariff rates
+    public List<TariffRateDto> getAllTariffRates() {
+        return tariffRateRepository.findAll().stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    // Get tariff rate by ID
+    public GenericResponse<TariffRateDto> getTariffRateById(Long id) {
+        TariffRateEntity entity = tariffRateRepository.findById(id)
+                .orElse(null);
+        if (entity == null) {
+            return new GenericResponse<TariffRateDto>(HttpStatus.NOT_FOUND, "Tariff Rate not found with id: " + id,
+                    null);
+        }
+        return new GenericResponse<TariffRateDto>(HttpStatus.OK, "Found", convertToDto(entity));
+    }
+
+    // Create a new tariff rate
+    public TariffRateDto createTariffRate(CreateTariffRateDto dto) {
+        TariffRateEntity entity = (convertToEntity(dto));
+        TariffRateEntity savedEntity = tariffRateRepository.save(entity);
+        return convertToDto(savedEntity);
+    }
+
+    // Update tariff rate
+    public GenericResponse<TariffRateDto> updateTariffRate(TariffRateDto dto, Long tariffRateId) {
+        TariffRateEntity existingEntity = tariffRateRepository.findById(tariffRateId)
+                .orElse(null);
+
+        if (existingEntity == null) {
+            return new GenericResponse<TariffRateDto>(HttpStatus.NOT_FOUND,
+                    "Tariff Rate not found with id: " + dto.getId(), null);
+        }
+
+        // Verify country code exists
+        CountryEntity importingCountry = getCountryEntityByCode(dto.getImportingCountryCode());
+        if (importingCountry == null) {
+            return new GenericResponse<TariffRateDto>(HttpStatus.NOT_FOUND,
+                    "Importing Country not found with code: " + dto.getImportingCountryCode(), null);
+        }
+        CountryEntity exportingCountry = getCountryEntityByCode(dto.getExportingCountryCode());
+        if (exportingCountry == null) {
+            return new GenericResponse<TariffRateDto>(HttpStatus.NOT_FOUND,
+                    "Exporting Country not found with code: " + dto.getExportingCountryCode(), null);
+        }
+
+        // Verify product category exists
+        // User has to create new product category separately if tariff needs a new one.
+        ProductCategoriesEntity productCategory = productCategoriesRepository
+                .findByCategoryCode(dto.getProductCategory().getCategoryCode())
+                .orElse(null);
+        if (productCategory == null) {
+            return new GenericResponse<TariffRateDto>(HttpStatus.NOT_FOUND,
+                    "Product Category not found with code: " + dto.getProductCategory().getCategoryCode(), null);
+        }
+
+        // Update fields
+        existingEntity.setTariffRate(dto.getTariffRate());
+        existingEntity.setTariffType(dto.getTariffType());
+        existingEntity.setRateUnit(dto.getRateUnit());
+        existingEntity.setEffectiveDate(dto.getEffectiveDate());
+        existingEntity.setExpiryDate(dto.getExpiryDate());
+        // CreatedAt should not be updated
+        existingEntity.setUpdatedAt(LocalDateTime.now());
+        existingEntity.setPreferentialTariff(dto.getPreferentialTariff());
+        existingEntity.setImportingCountry(importingCountry);
+        existingEntity.setExportingCountry(exportingCountry);
+        existingEntity.setProductCategory(productCategory);
+
+        TariffRateEntity updatedEntity = tariffRateRepository.save(existingEntity);
+        return new GenericResponse<TariffRateDto>(HttpStatus.OK, "Successfully updated Tariff Rate",
+                convertToDto(updatedEntity));
+    }
+
+    public GenericResponse<Void> deleteTariffRate(Long tariffRateId) {
+        if (!tariffRateRepository.existsById(tariffRateId)) {
+            return new GenericResponse<Void>(HttpStatus.NOT_FOUND, "Tariff Rate not found with id: " + tariffRateId,
+                    null);
+        }
+        tariffRateRepository.deleteById(tariffRateId);
+        // Eventually, handle national tariff lines associated with this tariff rate
+        return new GenericResponse<Void>(HttpStatus.OK, "Successfully deleted Tariff Rate", null);
+    }
+
+    /*
+     * Helper section
+     */
+
+    private TariffRateDto convertToDto(TariffRateEntity entity) {
+        TariffRateDto dto = new TariffRateDto();
+        dto.setId(entity.getId());
+        dto.setTariffRate(entity.getTariffRate());
+        dto.setTariffType(entity.getTariffType());
+        dto.setRateUnit(entity.getRateUnit());
+        dto.setEffectiveDate(entity.getEffectiveDate());
+        dto.setExpiryDate(entity.getExpiryDate());
+        dto.setPreferentialTariff(entity.getPreferentialTariff());
+        dto.setImportingCountryCode(entity.getImportingCountry().getCountryCode());
+        dto.setExportingCountryCode(entity.getExportingCountry().getCountryCode());
+        dto.setCreatedAt(entity.getCreatedAt());
+        dto.setUpdatedAt(entity.getUpdatedAt());
+        dto.setProductCategory(convertToDto(entity.getProductCategory()));
+        return dto;
+    }
+
+    private TariffRateEntity convertToEntity(CreateTariffRateDto dto) {
+        // Verify and get importing country
+        CountryEntity importingCountry = countryRepository.findByCountryCode(dto.getImportingCountryCode())
+                .orElseThrow(() -> new EntityNotFoundException("Importing Country not found"));
+
+        // Verify and get exporting country
+        CountryEntity exportingCountry = countryRepository.findByCountryCode(dto.getExportingCountryCode())
+                .orElseThrow(() -> new EntityNotFoundException("Exporting Country not found"));
+
+        // Handle Product Category - create if it doesn't exist
+        // Eventually, we may want to separate this out so that users have to create
+        // product
+        // categories first
+        ProductCategoriesEntity productCategory = productCategoriesRepository
+                .findByCategoryCode(dto.getProductCategory().getCategoryCode())
+                .orElse(new ProductCategoriesEntity(
+                        dto.getProductCategory().getCategoryCode(),
+                        dto.getProductCategory().getCategoryName(),
+                        dto.getProductCategory().getDescription()));
+
+        if (productCategory.getId() == null) {
+            productCategory = productCategoriesRepository.save(productCategory);
+        }
+
+        // // Handle National Tariff Line
+        // if (dto.getNationalTariffLine() != null) {
+        // // Check if national tariff line already exists for this country and tariff
+        // line code
+        // if (!nationalTariffLinesRepository.existsByCountryAndTariffLineCode(
+        // importingCountry,
+        // dto.getNationalTariffLine().getTariffLineCode())) {
+
+        // // Create new national tariff line if it doesn't exist
+        // NationalTariffLinesEntity nationalTariffLine = new NationalTariffLinesEntity(
+        // importingCountry,
+        // dto.getNationalTariffLine().getTariffLineCode(),
+        // dto.getNationalTariffLine().getDescription(),
+        // productCategory, // Use the product category as parent HS code
+        // dto.getNationalTariffLine().getLevel()
+        // );
+        // nationalTariffLinesRepository.save(nationalTariffLine);
+        // }
+        // }
+
+        // Create and return the TariffRate entity
+        return new TariffRateEntity(
+                importingCountry,
+                exportingCountry,
+                productCategory,
+                dto.getTariffRate(),
+                dto.getTariffType(),
+                dto.getRateUnit(),
+                dto.getEffectiveDate(),
+                dto.getExpiryDate(),
+                dto.getPreferentialTariff());
+    }
+
+    private ProductCategoriesDto convertToDto(ProductCategoriesEntity entity) {
+        ProductCategoriesDto dto = new ProductCategoriesDto();
+        dto.setId(entity.getId());
+        dto.setCategoryCode(entity.getCategoryCode());
+        dto.setCategoryName(entity.getCategoryName());
+        dto.setDescription(entity.getDescription());
+        dto.setIsActive(entity.getIsActive());
+        return dto;
+    }
+
+    private CountryEntity getCountryEntityByCode(String countryCode) {
+        return countryRepository.findByCountryCode(countryCode)
+                .orElseThrow(() -> new EntityNotFoundException("Country not found with code: " + countryCode));
+    }
+}


### PR DESCRIPTION
# SCRUM NUMBER:
SCRUM-20 


## Description
Basic CRUD endpoints relating to Tariff Rate entity has been implemented. More details:
- Added create endpoint for tariffs
- Added getById and getAll endpoints for tariffs
- Added update endpoint
- Added delete endpoint
- Added TariffRate controller, Service, and ServiceImpl

**NOTE:**
Clarification Needed: Tariff base rate is not updated anywhere -> Doesn't make sense to apply a global base rate when all countries have a diff rate?

ProductCategory update not yet implemented. 
As of now, when a new tariff rate is created, the ProductCategoriesEntity is created as well if the corresponding ProductCategories is not found in the database. If update to the TariffRateEntity happens as well, the ProductCategoriesEntity is also not updated even if the ProductCategoriesDto has changed. This will be tackled in another issue/ticket for ProductCategories CRUD operations itself.

At the moment, I have a Spring Security config disabling authentication or the need for login with the auto-generated Spring security password for APIs. We probably need to create  It resides in the core/security/SecurityConfig.java
```
package com.cs203.core.security;

import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.security.config.annotation.web.builders.HttpSecurity;
import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
import org.springframework.security.web.SecurityFilterChain;

@Configuration
@EnableWebSecurity
public class SecurityConfig {

    @Bean
    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
        http
            .csrf(csrf -> csrf.disable())  // Disable CSRF protection
            .authorizeHttpRequests(auth -> auth
                .requestMatchers("/**").permitAll()  // Allow all requests without authentication
            );
        
        return http.build();
    }
}
``` 

When creating the new tariff rate, the importing and exporting country must already exist in the database. Hence, initial countries has to be created already (for Tariff-rate entity to map to for importing and exporting countries). A simple one can be achieved by providing a data.sql script:
```
INSERT INTO country (country_code, country_name, region, currency_code) 
VALUES 
    ('SG', 'Singapore', 'Southeast Asia', 'SGD'),
    ('US', 'United States of America', 'North America', 'USD'),
    ('CN', 'China', 'East Asia', 'CNY'),
    ('JP', 'Japan', 'East Asia', 'JPY');
```
and appending this to application.properties
```
spring.jpa.defer-datasource-initialization=true
spring.sql.init.mode=always
spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
```
**AND RUNNING IT ONCE (remove after running gradle bootRun)**


## How Has This Been Tested?
Tested using Postman get, post, put, delete requests. Details of the actual request parameters and options are linked in the postman teams.


## Screenshots
getAll
<img width="1342" height="918" alt="image" src="https://github.com/user-attachments/assets/c25d0a7e-6a38-4af0-86f4-f5306d5e0cd4" />

get
<img width="1317" height="909" alt="image" src="https://github.com/user-attachments/assets/f6e0e73b-253a-4d11-97e8-4af2a078ebbd" />

update
<img width="1350" height="922" alt="image" src="https://github.com/user-attachments/assets/8c46f1c6-bd04-461a-ada0-4045899743af" />

create
<img width="1282" height="916" alt="image" src="https://github.com/user-attachments/assets/feec713d-bd07-440b-af2f-89d82bc0ec5b" />

delete
<img width="1374" height="952" alt="image" src="https://github.com/user-attachments/assets/69a9df8b-258f-4caa-8a18-12827b06e45b" />


## Checklist
<!--- Put an `x` in each box as you check off the items -->
- [x] I have performed a review of my changes locally
- [x] I have checked that no sensitive data is committed in the git history
- [x] I have checked that the correct labels are applied to the PR (e.g. `BREAKING CHANGE` if the PR introduces one)
- [x] I have added comments if my changes contain hard-to-understand logic
- [x] I have added tests and/or detailed the steps to verify that my changes are correct
- [x] I have updated any documentation if required
