### PR TITLE
chore: add missing branch test

### DIFF
--- a/core/src/test/java/com/cs203/core/resolver/CustomBearerTokenResolverTest.java
+++ b/core/src/test/java/com/cs203/core/resolver/CustomBearerTokenResolverTest.java
@@ -4,11 +4,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
-        import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.*;
 
 class CustomBearerTokenResolverTest {
 
@@ -114,6 +114,32 @@ class CustomBearerTokenResolverTest {
         when(request.getCookies()).thenReturn(cookies);
 
         String token = resolver.resolve(request);
+        assertNull(token);
+    }
+
+    @Test
+    void shouldCheckCookiesWhenHeaderTokenIsNull() {
+        // Arrange
+        CustomBearerTokenResolver spyResolver = spy(resolver);
+
+        when(request.getRequestURI()).thenReturn("/api/v1/tariff-rate");
+        when(request.getMethod()).thenReturn("GET");
+        // Simulate no Authorization header
+        when(request.getHeaders("Authorization"))
+                .thenReturn(Collections.emptyEnumeration());
+
+        // Force defaultResolver.resolve(request) to return null
+        doReturn(null)
+                .when(spyResolver)
+                .resolve(any(HttpServletRequest.class));
+
+        Cookie[] cookies = {new Cookie("accessToken", "cookie-token")};
+        when(request.getCookies()).thenReturn(cookies);
+
+        // Act
+        String token = spyResolver.resolve(request);
+
+        // Assert
         assertNull(token);
     }
 }


### PR DESCRIPTION
# SCRUM NUMBER:
<!--- Add scrum number here (e.g. SCRUM-3)-->


## Description
<!--- Provide a general summary and describe the changes in detail -->
adds missing branch test for resolver class

## Linked Issues
<!--- If it resolves any open issue, please link them here. -->
<!--- e.g. resolves #ISSUE_NUMBER (issues from the same repo) -->
<!--- e.g. resolves dsaidgovsg/tcs-ui#ISSUE_NUMBER (issues from an external repo) -->


## Hotfix Info (for hotfix > release PRs only)
<!--- Hotfix should first be merged back into `master`. --->
<!--- Please link to PR where this was done (e.g. #ISSUE_NUMBER) --->
<!--- If not, please state the reasons why the merge back is not needed. --->


## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots
<!--- Include images relevant to the PR here. --->


## Checklist
<!--- Put an `x` in each box as you check off the items -->
- [x] I have performed a review of my changes locally
- [x] I have checked that no sensitive data is committed in the git history
- [x] I have checked that the correct labels are applied to the PR (e.g. `BREAKING CHANGE` if the PR introduces one)
- [x] I have added comments if my changes contain hard-to-understand logic
- [x] I have added tests and/or detailed the steps to verify that my changes are correct
- [x] I have updated any documentation if required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated tests for authentication token handling: added cases ensuring cookie-based tokens are used when the Authorization header is missing or null, and that an existing Authorization header prevents cookie checks.
  * Minor test import formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->